### PR TITLE
SR-7266: Avoid nesting of ReversedCollection

### DIFF
--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -260,6 +260,19 @@ public struct ReversedRandomAccessCollection<
   public let _base: Base
 }
 
+extension ReversedCollection {
+  /// This is optimization to return identity of doubly reversed collection
+  /// For example [1,2].reversed().reversed() => [1,2]
+  /// 
+  /// Returns a view presenting the elements of the collection in reverse
+  /// order.
+  ///
+  /// - Complexity: O(1)
+  public func reversed() -> Base {
+    return _base
+  }
+}
+
 extension BidirectionalCollection {
   /// Returns a view presenting the elements of the collection in reverse
   /// order.


### PR DESCRIPTION
Applying reversed() two times should return identity.

<!-- What's in this pull request? -->
Optimization to avoid nesting of ReversedCollection, when applying the .reversed() multiple times.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7266](https://bugs.swift.org/browse/SR-7266).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
